### PR TITLE
add domain

### DIFF
--- a/uisp_respondd/respondd_client.py
+++ b/uisp_respondd/respondd_client.py
@@ -105,6 +105,7 @@ class NodeInfo:
     node_id: str
     location: LocationInfo
     network: NetworkInfo
+    system: SystemInfo
 
 
 @dataclasses.dataclass
@@ -250,6 +251,7 @@ class ResponddClient:
                             "bat0": IntInfo(interfaces=InterfacesInfo(other=[ap.mac]))
                         },
                     ),
+                    system=SystemInfo(domain_code=ap.domain_code),
                 )
             )
         return nodes

--- a/uisp_respondd/uisp_client.py
+++ b/uisp_respondd/uisp_client.py
@@ -28,6 +28,7 @@ class Accesspoint:
     latitude: float
     longitude: float
     neighbour: str
+    domain_code: str
 
 
 @dataclasses.dataclass
@@ -98,6 +99,7 @@ def get_infos():
                         latitude=float(get_location(device)[0]),
                         longitude=float(get_location(device)[1]),
                         neighbour=get_apDevice(device),
+                        domain_code="uisp_respondd_fallback",
                     )
                 )
     return aps


### PR DESCRIPTION
Based on https://github.com/freifunkMUC/unifi_respondd/pull/24

Using a generic, non `ffmuc` prefixed domain sounds like a preferred choice, as there is nothing ffmuc specific here as far as I can tell.